### PR TITLE
데이터 파이프라인 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ __pycache__
 # BE gitignore
 prototype/BE/webcrawling/.idea/
 
+prototype/ML/data/sampledata
 prototype/ML/data/rawdata
 prototype/ML/data/traindata

--- a/Prototype/ML/data/labeling.py
+++ b/Prototype/ML/data/labeling.py
@@ -12,7 +12,8 @@ def ocr_labeling(urls, n):
     pytesseract.pytesseract.tesseract_cmd = R'C:\Program Files\Tesseract-OCR\tesseract'
     ocr_keywords = ["제공", "업체", "협찬", "지급", "원고료"]
     
-    for idx, url in enumerate(urls[-n:]):
+    urls.reverse()
+    for idx, url in enumerate(urls[:n]):
         try:
             res = request.urlopen(url).read()
             img = Image.open(BytesIO(res))
@@ -22,7 +23,7 @@ def ocr_labeling(urls, n):
             continue
         
         if any(keyword in text for keyword in ocr_keywords):
-            return int(n - idx), url.split('/')[2]
+            return int(idx+1), url.split('/')[2]
     
     return int(0), None
 

--- a/Prototype/ML/data/labeling.py
+++ b/Prototype/ML/data/labeling.py
@@ -7,22 +7,22 @@ def ocr_labeling(urls, n):
     '''
     urls : 이미지 URL 리스트
     n : 살펴볼 이미지 URL의 수
-    return : 키워드 포함 여부, 포함되어 있던 URL
+    return : 키워드가 포함된 이미지 순서(맨 뒤가 1), 포함되어 있던 URL
     '''
     pytesseract.pytesseract.tesseract_cmd = R'C:\Program Files\Tesseract-OCR\tesseract'
     ocr_keywords = ["제공", "업체", "협찬", "지급", "원고료"]
     
-    for url in urls[-n:]:
+    for idx, url in enumerate(urls[-n:]):
         try:
             res = request.urlopen(url).read()
             img = Image.open(BytesIO(res))
             text = pytesseract.image_to_string(img, lang='kor').replace('\n', '').replace(' ', '')
         except:
-            print("Can't read image URL: "+url)
+            print("Can't read image URL: " + url)
             continue
         
         if any(keyword in text for keyword in ocr_keywords):
-            return int(1), url.split('/')[2]
+            return int(n - idx), url.split('/')[2]
     
     return int(0), None
 

--- a/Prototype/ML/data/main.py
+++ b/Prototype/ML/data/main.py
@@ -41,7 +41,7 @@ for file in files:
     df = df.astype({'label':'int'})
     
     # column 이름 정렬
-    df = df[['post_id', 'label', 'text_label', 'ocr_label', 'ocr_src', 'user_id', 
+    df = df[['label', 'text_label', 'ocr_label', 'ocr_src', 'post_id', 'user_id', 
              'post_link', 'blog_text', 'image_src']]
 
     result = pd.concat([result, df])

--- a/Prototype/ML/data/main.py
+++ b/Prototype/ML/data/main.py
@@ -37,7 +37,8 @@ for file in files:
     
     # 데이터 타입 변환 후 라벨링
     df = df.astype({'ocr_label':'int', 'text_label':'int'})
-    df['label'] = df['ocr_label'] | df['text_label']
+    df['label'] = (df['ocr_label'] > 0) | df['text_label']
+    df = df.astype({'label':'int'})
     
     # column 이름 정렬
     df = df[['post_id', 'label', 'text_label', 'ocr_label', 'ocr_src', 'user_id', 

--- a/Prototype/ML/data/main.py
+++ b/Prototype/ML/data/main.py
@@ -33,7 +33,7 @@ for file in files:
     
     # 이미지 URL OCR 후 키워드 검사
     df[['ocr_label', 'ocr_src']] = df.progress_apply(lambda x : ocr_labeling(
-                image_url_parse(x['image_src']), 1), axis=1, result_type='expand')
+                image_url_parse(x['image_src']), 5), axis=1, result_type='expand')
     
     # 데이터 타입 변환 후 라벨링
     df = df.astype({'ocr_label':'int', 'text_label':'int'})


### PR DESCRIPTION
변경 사항
1. 이전에는 OCR 후 키워드가 있는 경우 단순히 라벨을 1로 붙였으나 정보가 조금 부족하다고 판단되어 뒤에서 몇 번째 순서의 이미지에서 키워드가 있었는지 대한 정보를 추가했습니다. 따라서 전체 데이터를 처리한 이후에 뒤에서 몇 번째 이미지까지가 OCR하는 데에 유의미한지 결정할 수 있을 것 같습니다.
2. OCR 하는 순서를 제일 마지막 이미지부터 하도록 변경했습니다. 시간 개선이 정확히 어느 수준으로 이뤄지는지는 모르겠지만 반드시 개선이 있을 것으로 생각됩니다.
3. 테스트 데이터 디렉토리를 사용하기 위해서 gitignore가 변경되었습니다.
4. 파이프라인의 마지막에 나오는 데이터의 열 순서를 변경했습니다.